### PR TITLE
pwm: cv1800: Fix Output-Enable handling logic

### DIFF
--- a/drivers/pwm/pwm-cv1800.c
+++ b/drivers/pwm/pwm-cv1800.c
@@ -72,7 +72,8 @@ static int cv1800_pwm_enable(struct pwm_chip *chip, struct pwm_device *pwm,
 			     bool enable)
 {
 	struct cv1800_pwm *priv = to_cv1800_pwm_dev(chip);
-	u32 pwm_enable, state;
+	u32 pwm_enable;
+	unsigned int val;
 
 	regmap_read(priv->map, PWM_CV1800_START, &pwm_enable);
 	pwm_enable &= PWM_CV1800_START_MASK(pwm->hwpwm);
@@ -96,14 +97,10 @@ static int cv1800_pwm_enable(struct pwm_chip *chip, struct pwm_device *pwm,
 				   PWM_CV1800_START_MASK(pwm->hwpwm), 0);
 	}
 
-	/* check and set OE/Output-Enable mode */
-	regmap_read(priv->map, PWM_CV1800_OE, &state);
-
-	if ((state & BIT(pwm->hwpwm)) && enable)
-		regmap_update_bits(priv->map, PWM_CV1800_OE,
-				   PWM_CV1800_OE_MASK(pwm->hwpwm),
-				   PWM_CV1800_REG_ENABLE(pwm->hwpwm));
-
+	val = enable ? PWM_CV1800_REG_ENABLE(pwm->hwpwm) : 0;
+	/* set OE/Output-Enable mode */
+	regmap_update_bits(priv->map, PWM_CV1800_OE,
+			PWM_CV1800_OE_MASK(pwm->hwpwm), val);
 	return 0;
 }
 


### PR DESCRIPTION
pwm: cv1800: fix Output-Enable (OE) logic to restore PWM output

The original driver only set the OE bit when it was already set, which means
OE would never be enabled on first use. As a result, PWM output would not
appear even when period/duty_cycle and enable were correctly configured.

This patch fixes the OE control logic:

- Always set OE bit when enabling PWM, regardless of prior state
- Clear OE bit when disabling PWM
- Remove redundant OE state read & check

This resolves the issue of missing PWM signal on the output pin.

Tested on Sophgo CV1800 (Milkv Duo) board, using PWM1 (pin B11).
PWM signal verified via logic analyzer and sysfs interface.

To reproduce:

Pinmux was configured via:

```bash
[root@milkv-duo]~# duo-pinmux -w B11/PWM_1

[root@milkv-duo]~# ls /sys/class/pwm/pwmchip0/pwm1/
capture  duty_cycle  enable  period  polarity  power  uevent
[root@milkv-duo]~# echo 1 > /sys/class/pwm/pwmchip0/export
[root@milkv-duo]~# echo "normal" > /sys/class/pwm/pwmchip0/pwm1/polarity
[root@milkv-duo]~# echo 1000000 > /sys/class/pwm/pwmchip0/pwm1/period
[root@milkv-duo]~# echo 200000 > /sys/class/pwm/pwmchip0/pwm1/duty_cycle
[root@milkv-duo]~# echo 1 > /sys/class/pwm/pwmchip0/pwm1/enable

[root@milkv-duo]~# echo inversed > /sys/class/pwm/pwmchip0/pwm1/polarity

```

Observed 1 kHz 80%/20% duty waveform on B11.

![image](https://github.com/user-attachments/assets/3b913149-c490-460e-b4c0-f9a33ccef44f)

![image](https://github.com/user-attachments/assets/d1b15b26-8ba3-4608-a13a-09624a31ac8c)


Signed-off-by: eternal-echo [yu.yuan@sjtu.edu.cn](mailto:yu.yuan@sjtu.edu.cn)
